### PR TITLE
Use a metapackage for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pds/skeleton",
-    "type": "standard",
+    "type": "metapackage",
+    "keyword": ["standard"]
     "description": "Standard for PHP package skeletons.",
     "homepage": "https://github.com/php-pds/skeleton",
     "license": "CC-BY-SA-4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pds/skeleton",
     "type": "metapackage",
-    "keyword": ["standard"]
+    "keyword": ["standard"],
     "description": "Standard for PHP package skeletons.",
     "homepage": "https://github.com/php-pds/skeleton",
     "license": "CC-BY-SA-4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pds/skeleton",
     "type": "metapackage",
-    "keyword": ["standard"],
+    "keywords": ["standard"],
     "description": "Standard for PHP package skeletons.",
     "homepage": "https://github.com/php-pds/skeleton",
     "license": "CC-BY-SA-4.0"


### PR DESCRIPTION
As this package does not provide any code and is meant to be required as an indication of adoption, forcing all projects to download it does not make sense. Metapackages cover this case.