### PR TITLE
Generate/Validate skeletons in arbitrary path

### DIFF
--- a/src/ComplianceValidator.php
+++ b/src/ComplianceValidator.php
@@ -10,9 +10,9 @@ class ComplianceValidator
 
     protected $files = null;
 
-    public function execute()
+    public function execute($root = null)
     {
-        $lines = $this->getFiles();
+        $lines = $this->getFiles($root);
         $results = $this->validate($lines);
         $this->outputResults($results);
         return true;
@@ -52,10 +52,12 @@ class ComplianceValidator
     /**
      * Get list of files and directories previously set, or generate from parent project.
      */
-    public function getFiles()
+    public function getFiles($root = null)
     {
+        $root = $root ?: __DIR__ . '/../../../../';
+
         if ($this->files == null) {
-            $files = scandir(__DIR__ . "/../../../../");
+            $files = scandir($root);
             foreach ($files as $i => $file) {
                 if (is_dir($file)) {
                     $files[$i] .= "/";

--- a/src/ComplianceValidator.php
+++ b/src/ComplianceValidator.php
@@ -55,11 +55,12 @@ class ComplianceValidator
     public function getFiles($root = null)
     {
         $root = $root ?: __DIR__ . '/../../../../';
+        $root = realpath($root);
 
         if ($this->files == null) {
             $files = scandir($root);
             foreach ($files as $i => $file) {
-                if (is_dir($file)) {
+                if (is_dir("$root/$file")) {
                     $files[$i] .= "/";
                 }
             }

--- a/src/Console.php
+++ b/src/Console.php
@@ -31,7 +31,7 @@ class Console
     protected function executeCommand($commandClass, $args)
     {
         $command = new $commandClass();
-        return $command->execute($args);
+        return $command->execute(...$args);
     }
 
     protected function outputHelp()

--- a/src/PackageGenerator.php
+++ b/src/PackageGenerator.php
@@ -3,23 +3,24 @@ namespace Pds\Skeleton;
 
 class PackageGenerator
 {
-    public function execute()
+    public function execute($root = null)
     {
         $validator = new ComplianceValidator();
         $lines = $validator->getFiles();
         $validatorResults = $validator->validate($lines);
-        $files = $this->createFiles($validatorResults);
+        $files = $this->createFiles($validatorResults, $root);
         $this->outputResults($files);
         return true;
     }
 
     public function createFiles($validatorResults, $root = null)
     {
-        if ($root == null) {
-            $root = realpath(__DIR__ . "/../../../../");
-        }
+        $root = $root ?: __DIR__ . '/../../../../';
+        $root = realpath($root);
+
         $files = $this->createFileList($validatorResults);
         $createdFiles = [];
+
         foreach ($files as $i => $file) {
             $isDir = substr($file, -1, 1) == '/';
             if ($isDir) {
@@ -33,6 +34,7 @@ class PackageGenerator
             file_put_contents($path, '');
             chmod($path, 0644);
         }
+
         return $createdFiles;
     }
 


### PR DESCRIPTION
Currently, it's only possible to use the pds-skeleton when it's required locally. When it's required globally, it will only generate/validate packages in the `~/.composer` path.  

This pull-request enables the pds-skeleton to generate/validate package skeletons in any existing arbitrary path. If no path is provided, it will fallback to its default behavior. Here's a usage example:  

```shell
pds-skeleton generate path/to/existing/dir
pds-skeleton validate path/to/existing/package
```

Along the way, it fixes a bug in validator's `getFiles()` where it was unable to correctly detect if an entry is a directory or not. I didn't open a separate pull-request for this as it has merge conflicts with this one.