### PR TITLE
Fix for issue #41.

### DIFF
--- a/src/PackageGenerator.php
+++ b/src/PackageGenerator.php
@@ -6,7 +6,7 @@ class PackageGenerator
     public function execute($root = null)
     {
         $validator = new ComplianceValidator();
-        $lines = $validator->getFiles();
+        $lines = $validator->getFiles($root);
         $validatorResults = $validator->validate($lines);
         $files = $this->createFiles($validatorResults, $root);
         $this->outputResults($files);


### PR DESCRIPTION
Pass the needed command line arguments to the `getFiles()` method.