### PR TITLE
Check root folder permissions. Skip existing directories and files.

### DIFF
--- a/src/ComplianceValidator.php
+++ b/src/ComplianceValidator.php
@@ -14,8 +14,12 @@ class ComplianceValidator
     public function execute($root = null)
     {
         $lines = $this->getFiles($root);
-        $results = $this->validate($lines);
-        $this->outputResults($results);
+        try {
+            $results = $this->validate($lines);
+            $this->outputResults($results);
+        } catch (\Exception $e) {
+            echo $e->getMessage();
+        }
         return $this->getCompliant();
     }
 
@@ -67,6 +71,10 @@ class ComplianceValidator
     {
         $root = $root ?: __DIR__ . '/../../../../';
         $root = realpath($root);
+
+        if (!is_dir($root)) {
+            throw new GeneratorException("Specified directory does not exist. Remember to use an absolute path.");
+        }
 
         if ($this->files == null) {
             $files = scandir($root);

--- a/src/GeneratorException.php
+++ b/src/GeneratorException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Pds\Skeleton;
+
+class GeneratorException extends \Exception
+{
+
+}

--- a/src/PackageGenerator.php
+++ b/src/PackageGenerator.php
@@ -6,15 +6,14 @@ class PackageGenerator
     public function execute($root = null)
     {
         $validator = new ComplianceValidator();
-        $lines = $validator->getFiles($root);
-        $validatorResults = $validator->validate($lines);
         try {
+            $lines = $validator->getFiles($root);
+            $validatorResults = $validator->validate($lines);
             $files = $this->createFiles($validatorResults, $root);
+            $this->outputResults($files);
         } catch (\Exception $e) {
             echo $e->getMessage();
         }
-
-        $this->outputResults($files);
         return true;
     }
 
@@ -22,6 +21,10 @@ class PackageGenerator
     {
         $root = $root ?: __DIR__ . '/../../../../';
         $root = realpath($root);
+
+        if (!is_dir($root)) {
+            throw new GeneratorException("Specified directory does not exist. Remember to use an absolute path.");
+        }
 
         if (!is_writable($root) || !is_executable($root)) {
             throw new GeneratorException("Cannot write into specified directory. Please check folder permissions for {$root}");
@@ -39,7 +42,7 @@ class PackageGenerator
                 continue;
             }
             $path = $root . '/' . $file . '.md';
-            $createdFiles[$file] = $file . '.md';
+            $createdFiles[$file] = $path;
             if (!file_exists($path)) {
                 file_put_contents($path, '');
                 chmod($path, 0644);
@@ -69,8 +72,4 @@ class PackageGenerator
             echo "Created {$file}" . PHP_EOL;
         }
     }
-}
-
-class GeneratorException extends \Exception
-{
 }

--- a/src/PackageGenerator.php
+++ b/src/PackageGenerator.php
@@ -23,7 +23,7 @@ class PackageGenerator
         $root = realpath($root);
 
         if (!is_dir($root)) {
-            throw new GeneratorException("Specified directory does not exist. Remember to use an absolute path.");
+            throw new GeneratorException("Specified directory does not exist. Create it first.");
         }
 
         if (!is_writable($root) || !is_executable($root)) {

--- a/tests/PackageGeneratorTest.php
+++ b/tests/PackageGeneratorTest.php
@@ -7,8 +7,15 @@ class PackageGeneratorTest
 
     public static function run()
     {
+        set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, $severity, $severity, $file, $line);
+        });
+
         $tester = new PackageGeneratorTest();
         $tester->testGenerate_WithMissingBin_ReturnsBin();
+        $tester->testGenerate_WithExistingDir_SkipsDir();
+        $tester->testGenerate_WithExistingFile_SkipsFile();
+        $tester->testGenerate_WithBadPermissions_SkipsDirAndThrowsException();
         echo __CLASS__ . " errors: {$tester->numErrors}" . PHP_EOL;
     }
 
@@ -25,8 +32,7 @@ class PackageGeneratorTest
             ],
         ];
 
-        $generator = new PackageGenerator();
-        $files = $generator->createFileList($validatorResults);
+        $files = (new PackageGenerator())->createFileList($validatorResults);
 
         if (!array_key_exists('bin/', $files)) {
             $this->numErrors++;
@@ -37,5 +43,109 @@ class PackageGeneratorTest
             $this->numErrors++;
                 echo __FUNCTION__ . ": Expected config/ to be absent" . PHP_EOL;
         }
+    }
+
+    public function testGenerate_WithExistingDir_SkipsDir()
+    {
+        $validatorResults = [
+            'bin/' => [
+                'state' => ComplianceValidator::STATE_OPTIONAL_NOT_PRESENT,
+                'expected' => 'bin/',
+            ],
+        ];
+
+        $tmp = __DIR__.'/tmp_allowed';
+        $bin = $tmp.'/bin';
+        if (!is_dir($tmp)) {
+            mkdir($tmp, 0755);
+        }
+        if (!is_dir($bin)) {
+            mkdir($bin, 0755);
+        }
+
+        try {
+            $createdFiles = (new PackageGenerator())->createFiles($validatorResults, $tmp);
+        } catch (GeneratorException $e) {
+            $this->numErrors++;
+            echo __FUNCTION__ . ": Unexpected exception" . PHP_EOL;
+        }
+
+        if (!array_key_exists('bin/', $createdFiles)) {
+            $this->numErrors++;
+            echo __FUNCTION__ . ": Expected to return bin/" . PHP_EOL;
+        }
+
+        rmdir($tmp.'/bin');
+        rmdir($tmp);
+    }
+
+    public function testGenerate_WithExistingFile_SkipsFile()
+    {
+        $validatorResults = [
+            'LICENSE' => [
+                'state' => ComplianceValidator::STATE_RECOMMENDED_NOT_PRESENT,
+                'expected' => 'LICENSE',
+            ],
+        ];
+
+        $tmp = __DIR__.'/tmp_allowed';
+        $file = $tmp.'/LICENSE.md';
+        if (!is_dir($tmp)) {
+            mkdir($tmp, 0755);
+        }
+        touch($file);
+        file_put_contents($file, 'Original content');
+
+        try {
+            $createdFiles = (new PackageGenerator())->createFiles($validatorResults, $tmp);
+        } catch (GeneratorException $e) {
+            $this->numErrors++;
+            echo __FUNCTION__ . ': Unexpected exception' . PHP_EOL;
+        }
+
+        if (!array_key_exists('LICENSE', $createdFiles)) {
+            $this->numErrors++;
+            echo __FUNCTION__ . ': Expected to return file' . PHP_EOL;
+        }
+
+        if (file_get_contents($file) !== 'Original content') {
+            $this->numErrors++;
+            echo __FUNCTION__ . ': Expected to preserve original content' . PHP_EOL;
+        }
+
+        unlink($file);
+        rmdir($tmp);
+    }
+
+    public function testGenerate_WithBadPermissions_SkipsDirAndThrowsException()
+    {
+        $validatorResults = [
+            'bin/' => [
+                'state' => ComplianceValidator::STATE_OPTIONAL_NOT_PRESENT,
+                'expected' => 'bin/',
+            ],
+        ];
+
+        $tmp = __DIR__.'/tmp_forbidden';
+        if (!is_dir($tmp)) {
+            mkdir($tmp, 0644);
+        }
+
+        try {
+            (new PackageGenerator())->createFiles($validatorResults, $tmp);
+        } catch (GeneratorException $e) {
+            rmdir($tmp);
+            return;
+        }
+
+        $this->numErrors++;
+        echo __FUNCTION__ . ": Expected exception, but none was thrown" . PHP_EOL;
+
+        if (!is_dir($tmp.'/bin')) {
+            $this->numErrors++;
+            echo __FUNCTION__ . ": Expected to not create a directory, but bin/ was created" . PHP_EOL;
+        }
+
+        rmdir($tmp);
     }
 }


### PR DESCRIPTION
Fixes a number of bugs from #43:
- Check whether the specified folder exists and that it has sufficient permissions. 
- Output a message specific to each of the errors above.
- Existing folders and files do not cause a warning.
- Existing files do not get overridden.
- Add tests to prove the bugs in #43.