### PR TITLE
Use currrent working directory as default root path

### DIFF
--- a/src/ComplianceValidator.php
+++ b/src/ComplianceValidator.php
@@ -65,6 +65,7 @@ class ComplianceValidator
      */
     public function getFiles($root = null)
     {
+        $root = $root ?: getcwd();
         $root = $root ?: __DIR__ . '/../../../../';
         $root = realpath($root);
 

--- a/src/PackageGenerator.php
+++ b/src/PackageGenerator.php
@@ -15,6 +15,7 @@ class PackageGenerator
 
     public function createFiles($validatorResults, $root = null)
     {
+        $root = $root ?: getcwd();
         $root = $root ?: __DIR__ . '/../../../../';
         $root = realpath($root);
 


### PR DESCRIPTION
Currently both the generator and validator use a hard-coded root path
when no path argument is given. This can be unexpected especially when
you have pds-skeleton installed globally.

Changing it to the cwd will mean the following are the same:

    pds-skeleton validate
    pds-skeleton validate .

    pds-skeleton generate
    pds-skeleton generate .

If `getcwd()` returns false then it defaults to the original hard-coded
path.